### PR TITLE
Update template to Vapor 1.0

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,0 @@
-3.0-GM-CANDIDATE

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,8 @@
 import PackageDescription
 
 let package = Package(
-    name: "App",
+    name: "VaporApp",
     dependencies: [
-        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 0, minor: 18)
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 0)
     ]
 )

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an extremely lightweight, no frills starting point for Vapor application
 
 |Vapor|Xcode|Swift|
 |:-:|:-:|:-:|
-|0.18.x|8.0 GM|3.0-GM-Candidate|
+|1.0|8.0|3.0|
 
 ## 🛠 Setup
 

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -1,5 +1,7 @@
 import Vapor
 
 let drop = Droplet()
-drop.get("*") { request in request.description }
-drop.serve()
+
+drop.get { request in request.description }
+
+drop.run()


### PR DESCRIPTION
- Updated README (xcode, swift and vapor versions)
- Removed .swift-version, since it isn't needed and basic-template doesn't have one
- Updated Package.swift package name and vapor version
- Updated main.swift to the new API

Closes #2 
